### PR TITLE
Possibility to return array of keywords when no match

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ var important_keywords = headline_parser.findKeywords(headline, body, 3);
 
 findKeywords() accepts four arguments, of which the last two are optional. 
 
-    .findKeywords(headline, body [, n][, args]);
+    .findKeywords(headline, body [, n][, args][, returnNonMatched]);
 
 | Argument name | Description | Permitted values |
 |---------------|-------------|------------------|
 | headline| Headline of article | String|
 | body | Context from the article. May be the entire article body, or just a few sample sentences. The more context, the greater the accuracy of the parser.| String|
 | (optional) n | Number of top keywords desired. If left out, the parser will return all keywords sorted by relevance. | Integer |
-| (optional) returnNonMatched | Wether or not to return keywords from headline when no matches in body. If left out, and no match, the parser will not return any keywords. | Boolean |
 | (optional) args | Takes an object containing parameters for the [keyword-extractor module](https://www.npmjs.org/package/keyword-extractor) used to pull keywords from the headline. Default is {language:"english", return_changed_case:true} | Object (see [docs](https://www.npmjs.org/package/keyword-extractor))|
+| (optional) returnNonMatched | Wether or not to return keywords from headline when no matches in body. If left out, and no match, the parser will not return any keywords. | Boolean |
 
 ## Running tests
 
@@ -58,8 +58,3 @@ To run tests:
 It's pretty simple. This parser uses the [keyword-extractor](https://www.npmjs.org/package/keyword-extractor) module to obtain keywords from a headline (all non-stopwords), then sorts those words by how many times each word appears in the article body provided. For example, this is a great tool to use with the Twitter API if you plan to search or stream tweets that relate to a specific news article.
 
 Some things to note: The module will not count partial appearances of keywords, or compounded keywords. For instance, if one of your headline keywords is ['china'], then neither "China", "china's" or "Indochina" will be counted as an appearance of that keyword. Additionally, unless the `args` object is supplied with  a `return_changed_case: false` parameter, the module will count only the lowercase appearances of the word.
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ findKeywords() accepts four arguments, of which the last two are optional.
 | body | Context from the article. May be the entire article body, or just a few sample sentences. The more context, the greater the accuracy of the parser.| String|
 | (optional) n | Number of top keywords desired. If left out, the parser will return all keywords sorted by relevance. | Integer |
 | (optional) args | Takes an object containing parameters for the [keyword-extractor module](https://www.npmjs.org/package/keyword-extractor) used to pull keywords from the headline. Default is {language:"english", return_changed_case:true} | Object (see [docs](https://www.npmjs.org/package/keyword-extractor))|
-| (optional) returnNonMatched | Wether or not to return keywords from headline when no matches in body. If left out, and no match, the parser will not return any keywords. | Boolean |
+| (optional) returnNonMatched | Whether or not to return keywords from headline when no matches in body. If left out, and no match, the parser will default to {returnNonMatched:false} and not return any keywords. | Boolean |
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ findKeywords() accepts four arguments, of which the last two are optional.
 | headline| Headline of article | String|
 | body | Context from the article. May be the entire article body, or just a few sample sentences. The more context, the greater the accuracy of the parser.| String|
 | (optional) n | Number of top keywords desired. If left out, the parser will return all keywords sorted by relevance. | Integer |
+| (optional) returnNonMatched | Wether or not to return keywords from headline when no matches in body. If left out, and no match, the parser will not return any keywords. | Boolean |
 | (optional) args | Takes an object containing parameters for the [keyword-extractor module](https://www.npmjs.org/package/keyword-extractor) used to pull keywords from the headline. Default is {language:"english", return_changed_case:true} | Object (see [docs](https://www.npmjs.org/package/keyword-extractor))|
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-headline-parser
+eklem-headline-parser
 ===============
 
-A simple [NPM package](https://www.npmjs.org/package/headline-parser) that determines the most relevant keywords in a headline by considering article context.
+A forked version of [TessMyers](https://github.com/TessMyers) [headline-parser](https://github.com/TessMyers/headline-parser) [NPM package](https://www.npmjs.org/package/headline-parser) that determines the most relevant keywords in a headline by considering article context.
 
 ## Installation
 

--- a/headline-parser.js
+++ b/headline-parser.js
@@ -1,6 +1,6 @@
 var extractor = require('keyword-extractor');
 
-var findKeywords = function( headline, body, n, keywordArgs ){
+var findKeywords = function( headline, body, n, keywordArgs, returnNonMathched ){
   keywordArgs = keywordArgs || { language:"english", return_changed_case:true };
 
   body = body.split(' ');
@@ -25,12 +25,12 @@ var findKeywords = function( headline, body, n, keywordArgs ){
     }
   }
 
-  // If no keywords have been mentioned, return an error
+  // If no keywords have been mentioned, and 'returnNonMathched == true' return non matched keywords from headline
   var aboveZero = Object.keys(keywordCount).filter(function(key){ return keywordCount[key] > 0; })
 
   if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1) {
-    var message = 'Sorry, this headline appears to be completely irrelevant to the article body. Here are your keywords anyway: ' + keywordArray.join(', ');
-    return message;
+    var unSortedKeys = keywordArray.join(', ');
+    return unSortedKeys;
   }
 
 

--- a/headline-parser.js
+++ b/headline-parser.js
@@ -1,7 +1,8 @@
 var extractor = require('keyword-extractor');
 
-var findKeywords = function( headline, body, n, keywordArgs, returnNonMathched ){
+var findKeywords = function( headline, body, n, returnNonMathched, keywordArgs ){
   keywordArgs = keywordArgs || { language:"english", return_changed_case:true };
+  returnNonMatched = returnNonMatched || false;
 
   body = body.split(' ');
 

--- a/headline-parser.js
+++ b/headline-parser.js
@@ -1,7 +1,9 @@
 var extractor = require('keyword-extractor');
 
-var findKeywords = function( headline, body, n, returnNonMatched, keywordArgs ){
+var findKeywords = function( headline, body, n, keywordArgs, returnNonMatched ){
   keywordArgs = keywordArgs || { language:"english", return_changed_case:true };
+  
+  // Set returnNonMatched to false if not given
   returnNonMatched = returnNonMatched || false;
 
   body = body.split(' ');
@@ -29,17 +31,20 @@ var findKeywords = function( headline, body, n, returnNonMatched, keywordArgs ){
   // If no keywords have been mentioned, and 'returnNonMatched == true' return non matched keywords from headline
   var aboveZero = Object.keys(keywordCount).filter(function(key){ return keywordCount[key] > 0; })
 
-  if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && returnNonMatched) {
-    var nonMatchedKeys = keywordArray.join(', ');
-    return nonMatchedKeys;
+  if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && !returnNonMatched) {
+    return [];
   }
+  else if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && returnNonMatched) {
+    var nonMatchedKeys = keywordArray;
+    return nonMatchedKeys;
+  } 
+  else {
+    // Sort keywords by highest number of mentions
+    var sortedKeys = Object.keys(keywordCount).sort(function(a,b){return keywordCount[a] - keywordCount[b];});
 
-
-  // Sort keywords by highest number of mentions
-  var sortedKeys = Object.keys(keywordCount).sort(function(a,b){return keywordCount[a] - keywordCount[b];});
-
-  // Return last n important words, will return maximum if n is greater than max.
-  return sortedKeys.slice(-n);
+    // Return last n important words, will return maximum if n is greater than max.
+    return sortedKeys.slice(-n);
+  }
 }
 
 

--- a/headline-parser.js
+++ b/headline-parser.js
@@ -28,9 +28,9 @@ var findKeywords = function( headline, body, n, keywordArgs, returnNonMathched )
   // If no keywords have been mentioned, and 'returnNonMathched == true' return non matched keywords from headline
   var aboveZero = Object.keys(keywordCount).filter(function(key){ return keywordCount[key] > 0; })
 
-  if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1) {
-    var unSortedKeys = keywordArray.join(', ');
-    return unSortedKeys;
+  if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && returnNonMathched) {
+    var unMatchedKeys = keywordArray.join(', ');
+    return unMatchedKeys;
   }
 
 

--- a/headline-parser.js
+++ b/headline-parser.js
@@ -1,6 +1,6 @@
 var extractor = require('keyword-extractor');
 
-var findKeywords = function( headline, body, n, returnNonMathched, keywordArgs ){
+var findKeywords = function( headline, body, n, returnNonMatched, keywordArgs ){
   keywordArgs = keywordArgs || { language:"english", return_changed_case:true };
   returnNonMatched = returnNonMatched || false;
 
@@ -29,7 +29,7 @@ var findKeywords = function( headline, body, n, returnNonMathched, keywordArgs )
   // If no keywords have been mentioned, and 'returnNonMathched == true' return non matched keywords from headline
   var aboveZero = Object.keys(keywordCount).filter(function(key){ return keywordCount[key] > 0; })
 
-  if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && returnNonMathched) {
+  if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && returnNonMatched) {
     var unMatchedKeys = keywordArray.join(', ');
     return unMatchedKeys;
   }

--- a/headline-parser.js
+++ b/headline-parser.js
@@ -26,12 +26,12 @@ var findKeywords = function( headline, body, n, returnNonMatched, keywordArgs ){
     }
   }
 
-  // If no keywords have been mentioned, and 'returnNonMathched == true' return non matched keywords from headline
+  // If no keywords have been mentioned, and 'returnNonMatched == true' return non matched keywords from headline
   var aboveZero = Object.keys(keywordCount).filter(function(key){ return keywordCount[key] > 0; })
 
   if (Object.keys(keywordCount).length > 1 && aboveZero.length < 1 && returnNonMatched) {
-    var unMatchedKeys = keywordArray.join(', ');
-    return unMatchedKeys;
+    var nonMatchedKeys = keywordArray.join(', ');
+    return nonMatchedKeys;
   }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eklem-headline-parser",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Determines the most relevant keywords from an article headline",
   "main": "headline-parser.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "headline-parser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Determines the most relevant keywords from an article headline",
   "main": "headline-parser.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "headline-parser",
+  "name": "eklem-headline-parser",
   "version": "1.0.1",
   "description": "Determines the most relevant keywords from an article headline",
   "main": "headline-parser.js",
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/TessMyers/headline-parser.git"
+    "url": "https://github.com/eklem/eklem-headline-parser.git"
   },
   "keywords": [
     "parse",
@@ -19,12 +19,12 @@
     "relevance",
     "context"
   ],
-  "author": "tmyers <tcymyers@gmail.com> (http://www.tessmyers.com/)",
+  "author": "eklem <espen.klem@gmail.com> (http://lab.klemespen.com/)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/TessMyers/headline-parser/issues"
+    "url": "https://github.com/eklem/eklem-headline-parser/issues"
   },
-  "homepage": "https://github.com/TessMyers/headline-parser",
+  "homepage": "https://github.com/eklem/eklem-headline-parser",
   "dependencies": {
     "keyword-extractor": "0.0.10"
   },

--- a/test/headline-parser.js
+++ b/test/headline-parser.js
@@ -7,40 +7,44 @@ var stubs = [
     headline: 'Burkina Faso opposition parties, African Union reject army takeover',
     body: "OUAGADOUGOU (Reuters) - Burkina Faso's opposition parties, the United States and the African Union rejected the army's seizure of power in the West African country on Saturday after the resignation of President Blaise Compaore, setting the stage for fresh street protests.",
     n: 1,
+    returnNonMatched: false,
     args: {language:"english", return_changed_case:false}
   },
   {
     headline: "absolutely exclamation final",
     body: "final exclamation exclamation absolutely absolutely absolutely",
     n: 3,
-    args: {language:"english", return_changed_case:true},
+    returnNonMatched: false,
+    args: {language:"english", return_changed_case:false},
   },
   {
     headline: "a the and if",
     body: "a the and if and a the if and",
     n: null,
     args: null,
+    returnNonMatched: false,
   },
   {
     headline: "imperative otter shenanigans",
     body: "there are no mentions of the headline keywords in this sentence",
-    n: null,
-    args: {language:"english", return_changed_case:true},
+    n: 3,
+    args: {language:"english", return_changed_case:false},
+    returnNonMatched: false,
   },
 ]
 
 describe('findKeywords', function() {
   it('should return single most relevant keyword from title', function() {
-    findKeywords(stubs[0].headline, stubs[0].body, stubs[0].n, stubs[0].args).should.eql(['African']);
-    findKeywords(stubs[1].headline, stubs[1].body, 1, stubs[1].args).should.eql(['absolutely']);
+    findKeywords(stubs[0].headline, stubs[0].body, stubs[0].n, stubs[0].args, stubs[0].returnNonMatched).should.eql(['African']);
+    findKeywords(stubs[1].headline, stubs[1].body, 1, stubs[1].args, stubs[1].returnNonMatched).should.eql(['absolutely']);
   });
 
   it('should return top three keywords sorted by relevance. ', function() {
-    findKeywords(stubs[1].headline, stubs[1].body, stubs[1].n, stubs[1].args).should.eql(['final','exclamation','absolutely']);
+    findKeywords(stubs[1].headline, stubs[1].body, stubs[1].n, stubs[1].args, stubs[1].returnNonMatched).should.eql(['final','exclamation','absolutely']);
   });
 
   it('should return all keywords when no N or args argument is given', function() {
-    findKeywords(stubs[1].headline, stubs[1].body, null, null).should.eql(['final','exclamation','absolutely']);
+    findKeywords(stubs[1].headline, stubs[1].body, null, null, null).should.eql(['final','exclamation','absolutely']);
   });
 
   it('should return empty array if given empty strings', function() {
@@ -48,18 +52,21 @@ describe('findKeywords', function() {
   });
 
   it('should return empty array if headline has only stopwords', function() {
-    findKeywords(stubs[2].headline, stubs[2].body, stubs[2].n, stubs[2].args).should.eql([]);
+    findKeywords(stubs[2].headline, stubs[2].body, stubs[2].n, stubs[2].args, stubs[2].returnNonMatched).should.eql([]);
   });
 
   it('should return all sorted keywords if N is greater than number of keywords', function() {
-    findKeywords(stubs[1].headline, stubs[1].body, 10, stubs[1].args).should.eql(['final','exclamation','absolutely']);
+    findKeywords(stubs[1].headline, stubs[1].body, 10, stubs[1].args, null).should.eql(['final','exclamation','absolutely']);
   });
 
   it('should return all sorted keywords if no N is given', function() {
-    findKeywords(stubs[1].headline, stubs[1].body, null, stubs[1].args).should.eql(['final','exclamation','absolutely']);
+    findKeywords(stubs[1].headline, stubs[1].body, null, stubs[1].args, null).should.eql(['final','exclamation','absolutely']);
   });
 
-  it('should log an error if the headline keywords are not relevant to the article', function() {
-    findKeywords(stubs[3].headline, stubs[3].body, stubs[3].n, stubs[3].args).should.eql('Sorry, this headline appears to be completely irrelevant to the article body. Here are your keywords anyway: imperative, otter, shenanigans');
+  it('Should return no keywords since returnNonMatched defaults to false', function() {
+    findKeywords(stubs[3].headline, stubs[3].body, stubs[3].n, stubs[3].args, stubs[3].returnNonMatched).should.eql([]);
+  });
+  it('Should return keywords even if no match since returnNonMatched is true', function() {
+    findKeywords(stubs[3].headline, stubs[3].body, stubs[3].n, stubs[3].args, true).should.eql(['imperative','otter','shenanigans']);
   });
 });

--- a/test/headline-parser.js
+++ b/test/headline-parser.js
@@ -63,8 +63,11 @@ describe('findKeywords', function() {
     findKeywords(stubs[1].headline, stubs[1].body, null, stubs[1].args, null).should.eql(['final','exclamation','absolutely']);
   });
 
-  it('Should return no keywords since returnNonMatched defaults to false', function() {
+  it('Should return no keywords since returnNonMatched is set to to false', function() {
     findKeywords(stubs[3].headline, stubs[3].body, stubs[3].n, stubs[3].args, stubs[3].returnNonMatched).should.eql([]);
+  });
+  it('Should return no keywords since returnNonMatched defaults to false', function() {
+    findKeywords(stubs[3].headline, stubs[3].body, stubs[3].n, stubs[3].args, null).should.eql([]);
   });
   it('Should return keywords even if no match since returnNonMatched is true', function() {
     findKeywords(stubs[3].headline, stubs[3].body, stubs[3].n, stubs[3].args, true).should.eql(['imperative','otter','shenanigans']);


### PR DESCRIPTION
Removed the error message, only returns non-matched keywords if returnNonMatched variable is set to true. Added a couple of tests.
